### PR TITLE
Append the length of the input the message for CRC computation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Simple cross-platform command-line tool for computing **CRC-64** ([ECMA-182](htt
 
 Generator polynomial: **`0x42F0E1EBA9EA3693`**
 
+By default, the computation is initialized with `0xFFF…FFF`, the length of the input data is appended to the message, and the final CRC value is **not** negated. The default output format is hexadecimal (base-16), padded with leading zeros.
+
 ```
 Synopsis:
    crc64.exe [OPTIONS] [<file_1> [<file_2> ... <file_n>]]
@@ -16,14 +18,15 @@ Options:
    -u --upper-case      Print digest as upper-case (default is lower-case)
    -p --no-padding      Print digest *without* any leading zeros
    -s --silent          Suppress error messages
-   -e --ignore-errors   Ignore I/O errors and proceeed with the next file
+   -e --ignore-errors   Ignore I/O errors and proceed with the next file
    -f --no-flush        Do *not* flush output stream after each file
    -z --init-with-zero  Initialize CRC with 0x000..000 (default is 0xFFF..FFF)
+   -l --no-length       Do *not* append the input length to the message
    -n --negate-final    Negate the final CRC result
    -t --self-test       Run integrated self-test and exit program
 ```
 
 One output line is generated per input file:
 ```
-<CRC64-Checksum>[SP]<File-Size>[SP]<File-Name>[LF]
+<CRC64-Checksum> <File-Size> <File-Name>
 ```


### PR DESCRIPTION
For better `cksum` compatibility.